### PR TITLE
[PHP] Exit gracefully when receiving SIGINT

### DIFF
--- a/languages/php/Dockerfile
+++ b/languages/php/Dockerfile
@@ -1,4 +1,7 @@
 FROM php:8.1-cli
+
+RUN docker-php-ext-install pcntl
+
 COPY ./ .
 RUN curl -LO https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php
 RUN php datadog-setup.php --php-bin=all

--- a/languages/php/long-running-script.php
+++ b/languages/php/long-running-script.php
@@ -2,6 +2,20 @@
 
 namespace App;
 
+declare(ticks=1);
+
+\pcntl_signal(
+    SIGINT,
+    function ($signal) {
+        if ($signal === SIGINT) {
+            echo "Existing due to SIGINT\n";
+            exit(0);
+        } else {
+            echo "Handling signal $signal\n";
+        }
+    }
+);
+
 function root_function()
 {
     nested_function();


### PR DESCRIPTION
With this change the PHP long running script exposes the following exit behaviors

```
SIGINT	 exit code 0
SIGTERM  exit code 143
SIGKILL  exit code 137
```