### PR TITLE
Standardize Tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
     links:
       - mockagent
       - spammer
+    labels:
+        - "conc=${CONCURRENT_SPAMMERS}"
+        - "trunid=${TRANSPORT_RUN_ID}"
+        - "service=${DD_SERVICE}"
+        - "version=${DD_VERSION}"
     environment:
       - DD_DOGSTATSD_PORT=8125
       - DD_APM_ENABLED=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
         - "trunid=${TRANSPORT_RUN_ID}"
         - "service=${DD_SERVICE}"
         - "version=${DD_VERSION}"
+        - "transport=${TRANSPORT}"
     environment:
       - DD_DOGSTATSD_PORT=8125
       - DD_APM_ENABLED=false
@@ -30,7 +31,7 @@ services:
       - DD_SERVICE
       - DD_VERSION
       - DD_HOSTNAME=observer${HOST_POSTFIX}
-      - DD_CONTAINER_LABELS_AS_TAGS='{"trunid":"conc":"service":"version"}'
+      - DD_CONTAINER_LABELS_AS_TAGS='{"trunid":"conc":"service":"version":"transport"}'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /proc/:/host/proc/:ro
@@ -51,6 +52,7 @@ services:
         - "trunid=${TRANSPORT_RUN_ID}"
         - "service=${DD_SERVICE}"
         - "version=${DD_VERSION}"
+        - "transport=${TRANSPORT}"
     environment:
       - DD_APM_RECEIVER_PORT
       - DD_DOGSTATSD_PORT
@@ -91,6 +93,7 @@ services:
         - "trunid=${TRANSPORT_RUN_ID}"
         - "service=${DD_SERVICE}"
         - "version=${DD_VERSION}"
+        - "transport=${TRANSPORT}"
     environment:
       - DD_AGENT_HOST
       - DD_APM_RECEIVER_PORT
@@ -110,6 +113,7 @@ services:
       - DD_HOSTNAME=spammer${HOST_POSTFIX}
       - CONCURRENT_SPAMMERS
       - TRANSPORT_RUN_ID
+      - TRANSPORT
     volumes:
       - ./results/${TRANSPORT}/logs/tracer:/var/log/datadog
       - ./tmp/uds-volume/:/var/run/datadog
@@ -131,6 +135,7 @@ services:
       - DD_TRACE_GLOBAL_TAGS
       - CONCURRENT_SPAMMERS
       - TRANSPORT_RUN_ID
+      - TRANSPORT
     volumes:
       - ./tmp/uds-volume/:/var/run/datadog
     depends_on:

--- a/languages/dotnet/Program.cs
+++ b/languages/dotnet/Program.cs
@@ -11,7 +11,14 @@ var dogstatsdConfig = new StatsdConfig
 {
     StatsdServerName = "observer",
     StatsdPort = 8125,
-    ConstantTags = new [] { "language:dotnet" },
+    ConstantTags = new [] { 
+        "language:dotnet",
+        $"env:{Environment.GetEnvironmentVariable("DD_ENV")}",
+        $"service:{Environment.GetEnvironmentVariable("DD_SERVICE")}",
+        $"version:{Environment.GetEnvironmentVariable("DD_VERSION")}",
+        $"conc:{Environment.GetEnvironmentVariable("CONCURRENT_SPAMMERS")}",
+        $"trunid:{Environment.GetEnvironmentVariable("TRANSPORT_RUN_ID")}",
+    },
 };
 
 var tcs = new TaskCompletionSource();
@@ -41,9 +48,14 @@ AppDomain.CurrentDomain.ProcessExit += (_, _) =>
     }
 };
 
+int allSpans = 0;
+
 using (var dogStatsdService = new DogStatsdService())
 {
     dogStatsdService.Configure(dogstatsdConfig);
+
+    dogStatsdService.Increment("transport_sample.run", value: 1);
+
     while (!tcs.Task.IsCompleted)
     {
         using (var s1 = Datadog.Trace.Tracer.Instance.StartActive("spam"))
@@ -55,11 +67,17 @@ using (var dogStatsdService = new DogStatsdService())
                 Thread.Sleep(1);
             }
         }
+
+        allSpans += 2;
         
         dogStatsdService.Increment("transport_sample.span_created", value: 2);
     }
 
+
+    dogStatsdService.Increment("transport_sample.span_logged", value: allSpans);
+    dogStatsdService.Increment("transport_sample.end", value: 1);
     dogStatsdService.Flush();
 }
 
+Console.WriteLine($"Total spans created: {allSpans}");
 Console.WriteLine("Executing finalizer code.");

--- a/languages/dotnet/Program.cs
+++ b/languages/dotnet/Program.cs
@@ -18,6 +18,7 @@ var dogstatsdConfig = new StatsdConfig
         $"version:{Environment.GetEnvironmentVariable("DD_VERSION")}",
         $"conc:{Environment.GetEnvironmentVariable("CONCURRENT_SPAMMERS")}",
         $"trunid:{Environment.GetEnvironmentVariable("TRANSPORT_RUN_ID")}",
+        $"transport:{Environment.GetEnvironmentVariable("TRANSPORT")}",
     },
 };
 

--- a/languages/ruby/spammer.rb
+++ b/languages/ruby/spammer.rb
@@ -8,7 +8,7 @@ class Spammer
 
   def initialize
     # Setup metrics
-    @metrics = Datadog::Statsd.new('observer', 8125, tags: ["conc:#{ENV['CONCURRENT_SPAMMERS']}","trunid:#{ENV['TRANSPORT_RUN_ID']}","env:#{ENV['DD_ENV']}","service:#{ENV['DD_SERVICE']}","version:#{ENV['DD_VERSION']}","language:ruby"])
+    @metrics = Datadog::Statsd.new('observer', 8125, tags: ["transport:#{ENV['TRANSPORT']}","conc:#{ENV['CONCURRENT_SPAMMERS']}","trunid:#{ENV['TRANSPORT_RUN_ID']}","env:#{ENV['DD_ENV']}","service:#{ENV['DD_SERVICE']}","version:#{ENV['DD_VERSION']}","language:ruby"])
     @results = {}
   end
 

--- a/run.sh
+++ b/run.sh
@@ -115,7 +115,7 @@ rm -rf $OUTPUT_FOLDER
 mkdir -p $OUTPUT_FOLDER
 mkdir -p $LOGS_FOLDER
 
-export HOST_POSTFIX=${TRANSPORT_RUN_ID}-${TRACER}-conc${CONCURRENT_SPAMMERS}
+export HOST_POSTFIX=${TRANSPORT_RUN_ID}-${TRACER}-${TRANSPORT}-conc${CONCURRENT_SPAMMERS}
 
 echo ============ Run $TRANSPORT tests ===================
 echo "ℹ️  Results and logs outputted to ${OUTPUT_FOLDER}"


### PR DESCRIPTION
Standardizing tags and metrics sent for dashboard:

- [x] dotnet
- [ ] java (needs SIGINT and statsd introduced, delaying)
- [x] php
- [x] python (handled in https://github.com/DataDog/apm-transport-stress-tests/pull/17)
- [x] golang
- [x] ruby
- [ ] nodejs (having OOM issues in sample app, waiting)