### PR TITLE
Detect exit code from log file if docker misses

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -200,7 +200,17 @@ export DOCKER_CLIENT_TIMEOUT=120
 export COMPOSE_HTTP_TIMEOUT=120
 docker-compose down --remove-orphans
 
-echo "Spammer exited with $EXIT_CODE, test will fail on non-zero."
+echo "Docker compose detected exit code $EXIT_CODE."
+
+if [[ "$EXIT_CODE" == "0" ]]; then
+    # We should check the spammer log file just in case docker missed the exit code
+    echo "Checking log file for exit code."
+    PATTERN="exited with code [0-9]{1,4}"
+    SPAMMER_LOG=${LOGS_FOLDER}/spammer-stdout.log
+    LOG_EXIT_CODE=$(cat "${SPAMMER_LOG}" | grep -E "${PATTERN}" | grep -Eo "[0-9]{1,4}")
+    echo "Found exit code ${LOG_EXIT_CODE} in log file"
+    EXIT_CODE=$((LOG_EXIT_CODE))
+fi
 
 for unimplemented in java
 do
@@ -210,5 +220,5 @@ do
     fi
 done
 
-# This language has implemented SIGINT
+echo "Spammer exited with $EXIT_CODE, test will fail on non-zero."
 exit $EXIT_CODE


### PR DESCRIPTION
Java example output: 
![image](https://user-images.githubusercontent.com/1801443/179580016-eaa371a1-ec66-41c1-9b4b-fd4882ee9fb4.png)


This will fail once the Java SIGINT PR is accpeted.