### PR TITLE
Tone down concurrencies

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -109,7 +109,7 @@ jobs:
 
           - library: dotnet
             agent: realagent
-            concurrent: 35
+            concurrent: 30
           - library: nodejs
             agent: realagent
             concurrent: 50
@@ -121,10 +121,10 @@ jobs:
             concurrent: 50
           - library: ruby
             agent: realagent
-            concurrent: 40
+            concurrent: 35
           - library: java
             agent: realagent
-            concurrent: 30
+            concurrent: 25
           - library: php
             agent: realagent
             concurrent: 40

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -121,7 +121,7 @@ jobs:
             concurrent: 40
           - library: ruby
             agent: realagent
-            concurrent: 28
+            concurrent: 32
           - library: java
             agent: realagent
             concurrent: 23

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -109,10 +109,10 @@ jobs:
 
           - library: dotnet
             agent: realagent
-            concurrent: 25
+            concurrent: 30
           - library: nodejs
             agent: realagent
-            concurrent: 15
+            concurrent: 40
           - library: python
             agent: realagent
             concurrent: 25
@@ -121,13 +121,13 @@ jobs:
             concurrent: 40
           - library: ruby
             agent: realagent
-            concurrent: 25
+            concurrent: 28
           - library: java
             agent: realagent
-            concurrent: 20
+            concurrent: 23
           - library: php
             agent: realagent
-            concurrent: 25
+            concurrent: 32
 
       fail-fast: false
     steps:

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -112,7 +112,7 @@ jobs:
             concurrent: 25
           - library: nodejs
             agent: realagent
-            concurrent: 25
+            concurrent: 20
           - library: python
             agent: realagent
             concurrent: 25
@@ -121,10 +121,10 @@ jobs:
             concurrent: 40
           - library: ruby
             agent: realagent
-            concurrent: 35
+            concurrent: 25
           - library: java
             agent: realagent
-            concurrent: 25
+            concurrent: 20
           - library: php
             agent: realagent
             concurrent: 25

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -112,7 +112,7 @@ jobs:
             concurrent: 25
           - library: nodejs
             agent: realagent
-            concurrent: 20
+            concurrent: 15
           - library: python
             agent: realagent
             concurrent: 25

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -109,16 +109,16 @@ jobs:
 
           - library: dotnet
             agent: realagent
-            concurrent: 30
+            concurrent: 25
           - library: nodejs
             agent: realagent
-            concurrent: 50
+            concurrent: 25
           - library: python
             agent: realagent
-            concurrent: 30
+            concurrent: 25
           - library: golang
             agent: realagent
-            concurrent: 50
+            concurrent: 40
           - library: ruby
             agent: realagent
             concurrent: 35
@@ -127,7 +127,7 @@ jobs:
             concurrent: 25
           - library: php
             agent: realagent
-            concurrent: 40
+            concurrent: 25
 
       fail-fast: false
     steps:

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ AGENT_TYPE=${2}
 export ALTERNATIVE_LOAD_NEEDED=false
 export EXTRA_SPAMMER_TAG="concurrent-spammer"
 
-for highoverhead in none
+for highoverhead in nodejs
 do
     if [[ "$LANGUAGE" == "$highoverhead" ]]; then
         echo "Using the alternative load generator in the ./languages/load directory."

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ AGENT_TYPE=${2}
 export ALTERNATIVE_LOAD_NEEDED=false
 export EXTRA_SPAMMER_TAG="concurrent-spammer"
 
-for highoverhead in nodejs
+for highoverhead in none
 do
     if [[ "$LANGUAGE" == "$highoverhead" ]]; then
         echo "Using the alternative load generator in the ./languages/load directory."

--- a/run.sh
+++ b/run.sh
@@ -214,19 +214,23 @@ do
         echo "EVIDENCE: Found ${MATCHING_LINE_COUNT} lines matching - ${evidence}"
     } || { # catch
         echo "Failed checking agent log for ${evidence}"
-     }
+    }
 done
 
 echo "Docker compose detected exit code $EXIT_CODE."
+SPAMMER_LOG=${LOGS_FOLDER}/spammer-stdout.log
 
 if [[ "$EXIT_CODE" == "0" ]]; then
     # We should check the spammer log file just in case docker missed the exit code
     echo "Checking log file for exit code."
-    PATTERN="exited with code [0-9]{1,4}"
-    SPAMMER_LOG=${LOGS_FOLDER}/spammer-stdout.log
-    LOG_EXIT_CODE=$(cat "${SPAMMER_LOG}" | grep -E "${PATTERN}" | grep -Eo "[0-9]{1,4}")
-    echo "Found exit code ${LOG_EXIT_CODE} in log file"
-    EXIT_CODE=$((LOG_EXIT_CODE))
+    { # try  
+        PATTERN="exited with code [0-9]{1,4}"
+        LOG_EXIT_CODE=$(cat "${SPAMMER_LOG}" | grep -E "${PATTERN}" | grep -Eo "[0-9]{1,4}")
+        echo "Found exit code ${LOG_EXIT_CODE} in log file"
+        EXIT_CODE=$((LOG_EXIT_CODE))
+    } || { # catch
+        echo "Failed checking spammer log for exit code"
+    }
 fi
 
 if [[ "$TRACER" == "java" ]] && [[ "$EXIT_CODE" == "130" ]]; then

--- a/run.sh
+++ b/run.sh
@@ -204,6 +204,19 @@ export DOCKER_CLIENT_TIMEOUT=120
 export COMPOSE_HTTP_TIMEOUT=120
 docker-compose down --remove-orphans
 
+AGENT_LOG=${LOGS_FOLDER}/mockagent-stdout.log
+echo "Attempting to detect buffer problems in agent logs."
+
+for evidence in "unexpected EOF" "Cannot decode v0.4 traces payload" "too few bytes left to read" "i/o timeout"
+do
+    { # try  
+        MATCHING_LINE_COUNT=$(cat "${AGENT_LOG}" | grep -c "${evidence}")
+        echo "EVIDENCE: Found ${MATCHING_LINE_COUNT} lines matching - ${evidence}"
+    } || { # catch
+        echo "Failed checking agent log for ${evidence}"
+     }
+done
+
 echo "Docker compose detected exit code $EXIT_CODE."
 
 if [[ "$EXIT_CODE" == "0" ]]; then


### PR DESCRIPTION
Buffer overloaded in agent log:

- [x] dotnet
- [x] golang
- [x] python
- [x] ruby
- [x] java
- [x] php
- [x] nodejs (using golang as load)

Add grep counting for log evidence into run script.