### PR TITLE
Use dedicated VM for node debugging

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -12,122 +12,25 @@ on:
 
 jobs:
   stress-tests:
-    runs-on: ubuntu-latest
+    runs-on: transport-tests-main
     strategy:
       matrix:
         include:
-          # - library: dotnet
-          #   agent: mockagent
-
-          - library: dotnet
+          - library: nodejs
             agent: realagent
             concurrent: 0
           - library: nodejs
             agent: realagent
-            concurrent: 0
-          - library: python
-            agent: realagent
-            concurrent: 0
-          - library: golang
-            agent: realagent
-            concurrent: 0
-          - library: ruby
-            agent: realagent
-            concurrent: 0
-          - library: java
-            agent: realagent
-            concurrent: 0
-          - library: php
-            agent: realagent
-            concurrent: 0
-
-          - library: dotnet
-            agent: realagent
             concurrent: 2
           - library: nodejs
-            agent: realagent
-            concurrent: 2
-          - library: python
-            agent: realagent
-            concurrent: 2
-          - library: golang
-            agent: realagent
-            concurrent: 2
-          - library: ruby
-            agent: realagent
-            concurrent: 2
-          - library: java
-            agent: realagent
-            concurrent: 2
-          - library: php
-            agent: realagent
-            concurrent: 2
-
-          - library: dotnet
             agent: realagent
             concurrent: 5
           - library: nodejs
             agent: realagent
-            concurrent: 5
-          - library: python
-            agent: realagent
-            concurrent: 5
-          - library: golang
-            agent: realagent
-            concurrent: 5
-          - library: ruby
-            agent: realagent
-            concurrent: 5
-          - library: java
-            agent: realagent
-            concurrent: 5
-          - library: php
-            agent: realagent
-            concurrent: 5
-
-          - library: dotnet
-            agent: realagent
             concurrent: 10
           - library: nodejs
             agent: realagent
-            concurrent: 10
-          - library: python
-            agent: realagent
-            concurrent: 10
-          - library: golang
-            agent: realagent
-            concurrent: 10
-          - library: ruby
-            agent: realagent
-            concurrent: 10
-          - library: java
-            agent: realagent
-            concurrent: 10
-          - library: php
-            agent: realagent
-            concurrent: 10
-
-          - library: dotnet
-            agent: realagent
-            concurrent: 30
-          - library: nodejs
-            agent: realagent
-            concurrent: 11
-          - library: python
-            agent: realagent
-            concurrent: 25
-          - library: golang
-            agent: realagent
-            concurrent: 40
-          - library: ruby
-            agent: realagent
-            concurrent: 32
-          - library: java
-            agent: realagent
-            concurrent: 21
-          - library: php
-            agent: realagent
-            concurrent: 32
+            concurrent: 20
 
       fail-fast: false
     steps:


### PR DESCRIPTION
NOTES 2-14-2025: This is resolved, as we were in the middle off figuring out nodejs crashes, but we'll keep this PR around for historical purposes for a while.