### PR TITLE
fix nodejs unnecessary overhead from using high-level API

### DIFF
--- a/languages/nodejs/index.js
+++ b/languages/nodejs/index.js
@@ -30,8 +30,10 @@ const client = new StatsD({
 function nestedSpam (childOf, cb) {
   const span = tracer.startSpan('nested-spam', { childOf })
 
-  span.finish()
-  cb()
+  setTimeout(() => {
+    span.finish()
+    cb()
+  }, 1)
 }
 
 function spam (cb) {


### PR DESCRIPTION
Using `tracer.trace()` has much higher overhead than using the lower-level `tracer.startSpan()`. This can cause the process to hang for GC and various other problems that should not be present since the goal of this project is to isolate transport overhead, not the whole tracer overhead.

There was also a memory leak with the way the test was currently setup because it was recursive, meaning that all previous async resources were being held in memory by subsequent iterations.