### PR TITLE
update dd-trace-js and optimize its dockerfile

### DIFF
--- a/languages/nodejs/Dockerfile
+++ b/languages/nodejs/Dockerfile
@@ -7,8 +7,10 @@ RUN node --version && npm --version && curl --version
 
 WORKDIR /app
 
-COPY . ./
+COPY package.json package-lock.json ./
 
-RUN npm install dd-trace --save
+RUN npm install
+
+COPY index.js ./
 
 CMD ["node", "./index.js"]

--- a/languages/nodejs/package-lock.json
+++ b/languages/nodejs/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "dd-trace": "^2.8.0",
+        "dd-trace": "^2.12.2",
         "hot-shots": "^9.1.0"
       }
     },
     "node_modules/@datadog/native-appsec": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-1.2.0.tgz",
-      "integrity": "sha512-Brv9m8eKeJG8meeHd37V0Cz513TSce52nGRTEQ7O6/fmvlKGg64Z4HYasEZ1dRYwif0KPYPnZGvWHcnDld4ilA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-1.2.1.tgz",
+      "integrity": "sha512-jF+k7xhBmJIYYLtjvhCey08RBbItTG7O2zcSCDGFffhvCvo3ZOoou+IKtAm9z+U7hOoeOmD+Xg+h29xj/BB9MA==",
       "hasInstallScript": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@datadog/native-metrics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-1.2.0.tgz",
-      "integrity": "sha512-U1jXtN60+HL0KHzyYi9+QaNdbXqKjQGANSoqAdMCFzRG7ZuAQ8kjKng4RIY6QT/kOZQZ17UalrsqhUQjuVsRpA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-1.4.2.tgz",
+      "integrity": "sha512-ExSIZCEo3pXTNQRuyQllIa+0pc2bVDOntlx0JMnu7+GjeEjJxGyVLw8tTx5EQUmHSLt0Jm7aeMW63C8DJnO27A==",
       "hasInstallScript": true,
       "dependencies": {
         "nan": "^2.15.0",
@@ -44,25 +44,25 @@
       }
     },
     "node_modules/@datadog/pprof": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-0.4.0.tgz",
-      "integrity": "sha512-TG9w9xAqr/Dr6WI/StSirkGKiT9gQXMFx0zJeC/yjYtZWCO/8X7fwfCZJOMcQq4yBvMyKMDHFSNp1XVAKIRorQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-1.0.2.tgz",
+      "integrity": "sha512-AMTK55W3Aa2QX2X8mN9SQfDGw3HvwIK9Or8pXQFss+kjtH5pCkO9oqE5838MeXgRh9BR8HWrjAQE3Ji7FRCK2g==",
       "hasInstallScript": true,
       "dependencies": {
         "delay": "^5.0.0",
         "findit2": "^2.2.3",
-        "nan": "^2.14.0",
+        "nan": "^2.16.0",
         "node-gyp-build": "^3.9.0",
-        "p-limit": "^3.0.0",
+        "p-limit": "^3.1.0",
         "pify": "^5.0.0",
-        "protobufjs": "~6.11.0",
+        "protobufjs": "^7.0.0",
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "source-map": "^0.7.3",
         "split": "^1.0.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=12"
       }
     },
     "node_modules/@datadog/pprof/node_modules/semver": {
@@ -80,11 +80,41 @@
       }
     },
     "node_modules/@datadog/sketches-js": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@datadog/sketches-js/-/sketches-js-1.0.4.tgz",
-      "integrity": "sha512-9S5fdz448dLfGw4jSH1A4GZpkLWBufdsJu4PeevEjDvkauEmE175xBiBLfYHQEdKe7lEVNB4IRtUZqY16QRVUw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@datadog/sketches-js/-/sketches-js-1.0.5.tgz",
+      "integrity": "sha512-1ZKyHxxgDI+zY0r+7msMUhFdLR7gkRgKGcNLdYjtXVyo5H64q16J/Khfp5+YAXOedKizKzT0Jf0kLwQ/IBU/pA==",
       "dependencies": {
-        "protobufjs": "^6.10.2"
+        "protobufjs": "^6.11.3"
+      }
+    },
+    "node_modules/@datadog/sketches-js/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/@datadog/sketches-js/node_modules/protobufjs": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -147,14 +177,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg=="
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -187,17 +212,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -209,21 +223,20 @@
       "integrity": "sha512-/RC5F4l1SCqD/jazwUF6+t34Cd8zTSAGZ7rvvZu1whZUhD2a5MOGKjSGowoGcpj/cbVZk1ZODIooJEQQq3nNAA=="
     },
     "node_modules/dd-trace": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-2.8.0.tgz",
-      "integrity": "sha512-O5xl1elC70Om7VMJ95lOyqu6xZnjqX1zP1PkzUP0M4H2IMPo7VYzNOETzHqlxYX++vHtOfFoImgOV8lP6k0ItA==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-2.12.2.tgz",
+      "integrity": "sha512-ZRDDjuZl10CMDyJYair6dV87Zaz63NfOoon/r99fYdZi/ISAUtvun64OmOEdE3Kl8A3LOL4wY25nvB3YTDnwjA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@datadog/native-appsec": "^1.2.0",
-        "@datadog/native-metrics": "^1.2.0",
-        "@datadog/pprof": "^0.4.0",
-        "@datadog/sketches-js": "^1.0.4",
+        "@datadog/native-appsec": "^1.2.1",
+        "@datadog/native-metrics": "^1.4.2",
+        "@datadog/pprof": "^1.0.2",
+        "@datadog/sketches-js": "^1.0.5",
         "@types/node": ">=12",
         "crypto-randomuuid": "^1.0.0",
         "diagnostics_channel": "^1.1.0",
-        "form-data": "^3.0.0",
         "ignore": "^5.2.0",
-        "import-in-the-middle": "^1.2.1",
+        "import-in-the-middle": "^1.3.0",
         "koalas": "^1.0.2",
         "limiter": "^1.1.4",
         "lodash.kebabcase": "^4.1.1",
@@ -234,7 +247,6 @@
         "module-details-from-path": "^1.0.3",
         "opentracing": ">=0.12.1",
         "path-to-regexp": "^0.1.2",
-        "performance-now": "^2.1.0",
         "retry": "^0.10.1",
         "semver": "^5.5.0"
       },
@@ -253,18 +265,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -289,22 +293,9 @@
     "node_modules/findit2": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/findit2/-/findit2-2.2.3.tgz",
-      "integrity": "sha1-WKRmaX34piBc39vzlVNri9d3pfY=",
+      "integrity": "sha512-lg/Moejf4qXovVutL0Lz4IsaPoNYMuxt4PA0nGqFxnJ1CTTGGlEO2wKgoDpwknhvZ8k4Q2F+eesgkLbG2Mxfog==",
       "engines": {
         "node": ">=0.8.22"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fs-minipass": {
@@ -321,7 +312,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -362,9 +353,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.2.1.tgz",
-      "integrity": "sha512-KdYqCJbJWBOU9740nr9lrmCDhW7htxY1dHmbP4iUEeCaxupj2fKFhyHixsly2WmxMbRIsxzSWSJMfGNEU7el+w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.0.tgz",
+      "integrity": "sha512-esDCEWyzzg0bGShz1N5ybRrPIJFvKaJ7TfTaIFP1XovxFo98In2GiDpOR/Cn/8J1cfRO8i/RrQToQ9j0WL2b0Q==",
       "dependencies": {
         "module-details-from-path": "^1.0.3"
       }
@@ -372,7 +363,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -417,9 +408,9 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -436,25 +427,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
       "engines": {
         "node": ">= 0.6"
       }
@@ -476,9 +448,9 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minipass": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
-      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -512,7 +484,7 @@
     "node_modules/module-details-from-path": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-      "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
     },
     "node_modules/nan": {
       "version": "2.16.0",
@@ -532,7 +504,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
       }
@@ -562,7 +534,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -571,11 +543,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "node_modules/pify": {
       "version": "5.0.0",
@@ -589,9 +556,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.0.0.tgz",
+      "integrity": "sha512-ffNIEm+quOcYtQvHdW406v1NQmZSuqVklxsXk076BtuFnlYZfigLU+JOMrTD8TUOyqHYbRI/fSVNvgd25YeN3w==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -606,11 +573,10 @@
         "@protobufjs/utf8": "^1.1.0",
         "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/retry": {
@@ -644,9 +610,9 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "engines": {
         "node": ">= 8"
       }
@@ -681,7 +647,7 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "node_modules/unix-dgram": {
       "version": "2.0.4",
@@ -700,7 +666,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -721,9 +687,9 @@
   },
   "dependencies": {
     "@datadog/native-appsec": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-1.2.0.tgz",
-      "integrity": "sha512-Brv9m8eKeJG8meeHd37V0Cz513TSce52nGRTEQ7O6/fmvlKGg64Z4HYasEZ1dRYwif0KPYPnZGvWHcnDld4ilA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-1.2.1.tgz",
+      "integrity": "sha512-jF+k7xhBmJIYYLtjvhCey08RBbItTG7O2zcSCDGFffhvCvo3ZOoou+IKtAm9z+U7hOoeOmD+Xg+h29xj/BB9MA==",
       "requires": {
         "detect-libc": "^1.0.3",
         "minimist": "^1.2.6",
@@ -731,26 +697,26 @@
       }
     },
     "@datadog/native-metrics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-1.2.0.tgz",
-      "integrity": "sha512-U1jXtN60+HL0KHzyYi9+QaNdbXqKjQGANSoqAdMCFzRG7ZuAQ8kjKng4RIY6QT/kOZQZ17UalrsqhUQjuVsRpA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-1.4.2.tgz",
+      "integrity": "sha512-ExSIZCEo3pXTNQRuyQllIa+0pc2bVDOntlx0JMnu7+GjeEjJxGyVLw8tTx5EQUmHSLt0Jm7aeMW63C8DJnO27A==",
       "requires": {
         "nan": "^2.15.0",
         "node-gyp-build": "^3.9.0"
       }
     },
     "@datadog/pprof": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-0.4.0.tgz",
-      "integrity": "sha512-TG9w9xAqr/Dr6WI/StSirkGKiT9gQXMFx0zJeC/yjYtZWCO/8X7fwfCZJOMcQq4yBvMyKMDHFSNp1XVAKIRorQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-1.0.2.tgz",
+      "integrity": "sha512-AMTK55W3Aa2QX2X8mN9SQfDGw3HvwIK9Or8pXQFss+kjtH5pCkO9oqE5838MeXgRh9BR8HWrjAQE3Ji7FRCK2g==",
       "requires": {
         "delay": "^5.0.0",
         "findit2": "^2.2.3",
-        "nan": "^2.14.0",
+        "nan": "^2.16.0",
         "node-gyp-build": "^3.9.0",
-        "p-limit": "^3.0.0",
+        "p-limit": "^3.1.0",
         "pify": "^5.0.0",
-        "protobufjs": "~6.11.0",
+        "protobufjs": "^7.0.0",
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "source-map": "^0.7.3",
@@ -768,11 +734,38 @@
       }
     },
     "@datadog/sketches-js": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@datadog/sketches-js/-/sketches-js-1.0.4.tgz",
-      "integrity": "sha512-9S5fdz448dLfGw4jSH1A4GZpkLWBufdsJu4PeevEjDvkauEmE175xBiBLfYHQEdKe7lEVNB4IRtUZqY16QRVUw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@datadog/sketches-js/-/sketches-js-1.0.5.tgz",
+      "integrity": "sha512-1ZKyHxxgDI+zY0r+7msMUhFdLR7gkRgKGcNLdYjtXVyo5H64q16J/Khfp5+YAXOedKizKzT0Jf0kLwQ/IBU/pA==",
       "requires": {
-        "protobufjs": "^6.10.2"
+        "protobufjs": "^6.11.3"
+      },
+      "dependencies": {
+        "long": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "protobufjs": {
+          "version": "6.11.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+          "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": ">=13.7.0",
+            "long": "^4.0.0"
+          }
+        }
       }
     },
     "@protobufjs/aspromise": {
@@ -835,14 +828,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/node": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg=="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -872,14 +860,6 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -891,20 +871,19 @@
       "integrity": "sha512-/RC5F4l1SCqD/jazwUF6+t34Cd8zTSAGZ7rvvZu1whZUhD2a5MOGKjSGowoGcpj/cbVZk1ZODIooJEQQq3nNAA=="
     },
     "dd-trace": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-2.8.0.tgz",
-      "integrity": "sha512-O5xl1elC70Om7VMJ95lOyqu6xZnjqX1zP1PkzUP0M4H2IMPo7VYzNOETzHqlxYX++vHtOfFoImgOV8lP6k0ItA==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-2.12.2.tgz",
+      "integrity": "sha512-ZRDDjuZl10CMDyJYair6dV87Zaz63NfOoon/r99fYdZi/ISAUtvun64OmOEdE3Kl8A3LOL4wY25nvB3YTDnwjA==",
       "requires": {
-        "@datadog/native-appsec": "^1.2.0",
-        "@datadog/native-metrics": "^1.2.0",
-        "@datadog/pprof": "^0.4.0",
-        "@datadog/sketches-js": "^1.0.4",
+        "@datadog/native-appsec": "^1.2.1",
+        "@datadog/native-metrics": "^1.4.2",
+        "@datadog/pprof": "^1.0.2",
+        "@datadog/sketches-js": "^1.0.5",
         "@types/node": ">=12",
         "crypto-randomuuid": "^1.0.0",
         "diagnostics_channel": "^1.1.0",
-        "form-data": "^3.0.0",
         "ignore": "^5.2.0",
-        "import-in-the-middle": "^1.2.1",
+        "import-in-the-middle": "^1.3.0",
         "koalas": "^1.0.2",
         "limiter": "^1.1.4",
         "lodash.kebabcase": "^4.1.1",
@@ -915,7 +894,6 @@
         "module-details-from-path": "^1.0.3",
         "opentracing": ">=0.12.1",
         "path-to-regexp": "^0.1.2",
-        "performance-now": "^2.1.0",
         "retry": "^0.10.1",
         "semver": "^5.5.0"
       }
@@ -925,15 +903,10 @@
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
       "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw=="
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="
     },
     "diagnostics_channel": {
       "version": "1.1.0",
@@ -949,17 +922,7 @@
     "findit2": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/findit2/-/findit2-2.2.3.tgz",
-      "integrity": "sha1-WKRmaX34piBc39vzlVNri9d3pfY="
-    },
-    "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
+      "integrity": "sha512-lg/Moejf4qXovVutL0Lz4IsaPoNYMuxt4PA0nGqFxnJ1CTTGGlEO2wKgoDpwknhvZ8k4Q2F+eesgkLbG2Mxfog=="
     },
     "fs-minipass": {
       "version": "2.1.0",
@@ -972,7 +935,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "glob": {
       "version": "7.2.3",
@@ -1001,9 +964,9 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
     "import-in-the-middle": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.2.1.tgz",
-      "integrity": "sha512-KdYqCJbJWBOU9740nr9lrmCDhW7htxY1dHmbP4iUEeCaxupj2fKFhyHixsly2WmxMbRIsxzSWSJMfGNEU7el+w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.0.tgz",
+      "integrity": "sha512-esDCEWyzzg0bGShz1N5ybRrPIJFvKaJ7TfTaIFP1XovxFo98In2GiDpOR/Cn/8J1cfRO8i/RrQToQ9j0WL2b0Q==",
       "requires": {
         "module-details-from-path": "^1.0.3"
       }
@@ -1011,7 +974,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1053,9 +1016,9 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -1069,19 +1032,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "requires": {
-        "mime-db": "1.52.0"
-      }
     },
     "minimatch": {
       "version": "3.1.2",
@@ -1097,9 +1047,9 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
-      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -1121,7 +1071,7 @@
     "module-details-from-path": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-      "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
     },
     "nan": {
       "version": "2.16.0",
@@ -1136,7 +1086,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "requires": {
         "wrappy": "1"
       }
@@ -1157,17 +1107,12 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "5.0.0",
@@ -1175,9 +1120,9 @@
       "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
     },
     "protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.0.0.tgz",
+      "integrity": "sha512-ffNIEm+quOcYtQvHdW406v1NQmZSuqVklxsXk076BtuFnlYZfigLU+JOMrTD8TUOyqHYbRI/fSVNvgd25YeN3w==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -1191,7 +1136,7 @@
         "@protobufjs/utf8": "^1.1.0",
         "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       }
     },
     "retry": {
@@ -1213,9 +1158,9 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
     },
     "split": {
       "version": "1.0.1",
@@ -1241,7 +1186,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "unix-dgram": {
       "version": "2.0.4",
@@ -1256,7 +1201,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/languages/nodejs/package.json
+++ b/languages/nodejs/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "dd-trace": "^2.8.0",
+    "dd-trace": "^2.12.2",
     "hot-shots": "^9.1.0"
   }
 }


### PR DESCRIPTION
This version fixes the differences in overhead between TCP and UDS. There is still 1 error that pops up from time to time in concurrency 0, but it happens with both transports and can be investigated later.